### PR TITLE
Add Vite typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ npm run dev
 npm test
 ```
 
+### 6. TypeScript Build
+
+The source code in `src/` is written entirely in TypeScript. A `tsconfig.json`
+and `vite-env.d.ts` are provided so the project can be compiled with `tsc`
+before the Vite build process. To compile the TypeScript sources run:
+
+```bash
+npm run build
+```
+
+When migrating new JavaScript files, tools such as **ts-morph** or
+**ts-migrate** can help automate the conversion.
+
 ## Usage
 
 ### Admin Access

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
+import App from './App'
 import './App.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "strict": true,
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "typeRoots": ["./node_modules/@types"],
+    "types": ["vite/client", "vitest"],
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- configure TS to load type declarations
- add `vite-env.d.ts`
- document the new typings in README

## Testing
- `npx tsc --noEmit` *(fails: cannot find type definition files)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c705f84f48323bf5e996fa1e4182f